### PR TITLE
updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Endpoints:
 
  * GET personalitytest.herokuapp.com/api/v1/questions
 
- * POST personalitytest.herokuapp.com/api/v1/questions
+ * POST personalitytest.herokuapp.com/api/v1/answers
 
 POST requires json params `{"location" => whatever your url is, "answers" => {"3" => "2", "50" => "5"}}`.
 Inner "answer params" has the question id as they key. The value is the user's response for that question (between 1 and 5). Should have 50 answer responses. The response simply returns the following JSON key/value pairs:<br>


### PR DESCRIPTION
under "POST" endpoint, changed the endpoint to /answers from /questions. 

Found this error after looking through https://purrrsonalitytest.herokuapp.com/ sources when inspecting element. The site uses /answers whereas the readme currently uses /questions for the POST endpoint.